### PR TITLE
fix: prevent panic on thread if no mount is selected

### DIFF
--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -73,6 +73,13 @@ pub async fn search_directory(
     accept_files: bool,
     accept_directories: bool,
 ) -> Result<Vec<DirectoryChild>, ()> {
+
+    // mount_pnt needs a default value or to be an optional 
+    if mount_pnt == "" {
+        println!("select a mount point by clicking on an icon"); // move to ui
+        return Err(())
+    }
+
     let start_time = Instant::now();
 
     let mut results: Vec<_> = Vec::new();

--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -73,13 +73,6 @@ pub async fn search_directory(
     accept_files: bool,
     accept_directories: bool,
 ) -> Result<Vec<DirectoryChild>, ()> {
-
-    // mount_pnt needs a default value or to be an optional 
-    if mount_pnt == "" {
-        println!("select a mount point by clicking on an icon"); // move to ui
-        return Err(())
-    }
-
     let start_time = Instant::now();
 
     let mut results: Vec<_> = Vec::new();

--- a/src/components/TopBar/SearchBar.tsx
+++ b/src/components/TopBar/SearchBar.tsx
@@ -14,7 +14,7 @@ export interface ISearchFilter {
   extension: string;
   acceptFiles: boolean;
   acceptDirectories: boolean;
-}``
+}
 
 export default function SearchBar({
   currentDirectoryPath,

--- a/src/components/TopBar/SearchBar.tsx
+++ b/src/components/TopBar/SearchBar.tsx
@@ -14,7 +14,7 @@ export interface ISearchFilter {
   extension: string;
   acceptFiles: boolean;
   acceptDirectories: boolean;
-}
+}``
 
 export default function SearchBar({
   currentDirectoryPath,
@@ -32,6 +32,11 @@ export default function SearchBar({
   const currentPlace = split[split.length - 2];
 
   async function onSearch() {
+    if (currentVolume.length == 0) {
+      alert("Please select a volume before searching.");
+      return;
+    }
+
     const results = await invoke<DirectoryContent[]>("search_directory", {
       query: searchValue,
       searchDirectory: currentDirectoryPath,


### PR DESCRIPTION
Just a simple fix
You can see the bug if you try to search before selecting a drive,
the drive is set to "" and an unwrap none panics a thread

something like

thread 'tokio-runtime-worker' panicked at 'called `Option::unwrap()` on a `None` value', src/search.rs:88:59
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', src/search.rs:85:34
thread 'notify-rs fsevents loop' panicked at 'called `Result::unwrap()` on an `Err` value: PoisonError { .. }', src/filesystem/cache.rs:48:48


I think this should be set to all mounts or the 0th by defualt, and outlined in the ui somehow


@conaticus 

i think this may fix part of https://github.com/conaticus/FileExplorer/issues/26



