### PR TITLE
made mountpoint retrieval cross-platform

### DIFF
--- a/src-tauri/src/filesystem/fs_utils.rs
+++ b/src-tauri/src/filesystem/fs_utils.rs
@@ -7,6 +7,6 @@ pub fn get_mount_point(path: String) -> Option<String> {
 
     let mut mount_point_path = PathBuf::new();
     mount_point_path.push(&mount_point);
-    mount_point_path.push("\\");
+    mount_point_path = mount_point_path.canonicalize().unwrap();
     Some(mount_point_path.to_string_lossy().into_owned())
 }


### PR DESCRIPTION
Very small change that removes the windows bias ('\\' is not a path separator on unix systems, this would result in the program erroring out on any of the file operations)

This PR makes the path canonical, meaning it expands the whole path to it's absolute path. So on most unix systems it would give you `/` or `/home/user` or whatever mountpoint is being used. On windows it would give you `C:\\` or equivalent lettered disks.