### PR TITLE
Adds `FileType` enum

### DIFF
--- a/src-tauri/src/filesystem/cache.rs
+++ b/src-tauri/src/filesystem/cache.rs
@@ -1,4 +1,4 @@
-use crate::filesystem::{DIRECTORY, FILE};
+use crate::filesystem::FileType;
 use crate::{AppState, CachedPath, StateSafe, VolumeCache};
 use lazy_static::lazy_static;
 use notify::event::{CreateKind, ModifyKind, RenameMode};
@@ -50,11 +50,10 @@ impl FsEventHandler {
 
         let filename = path.file_name().unwrap().to_string_lossy().to_string();
         let file_type = match kind {
-            CreateKind::File => FILE,
-            CreateKind::Folder => DIRECTORY,
+            CreateKind::File => FileType::File,
+            CreateKind::Folder => FileType::Directory,
             _ => return, // Other options are weird lol
-        }
-            .to_string();
+        };
 
         let file_path = path.to_string_lossy().to_string();
         current_volume.entry(filename).or_insert_with(|| vec![CachedPath {
@@ -97,12 +96,12 @@ impl FsEventHandler {
         let current_volume = self.get_from_cache(state);
 
         let filename = new_path.file_name().unwrap().to_string_lossy().to_string();
-        let file_type = if new_path.is_dir() { DIRECTORY } else { FILE };
+        let file_type = if new_path.is_dir() { FileType::Directory } else { FileType::File };
 
         let path_string = new_path.to_string_lossy().to_string();
         current_volume.entry(filename).or_insert_with(|| vec![CachedPath {
             file_path: path_string,
-            file_type: String::from(file_type),
+            file_type: file_type,
         }]);
     }
 

--- a/src-tauri/src/filesystem/explorer.rs
+++ b/src-tauri/src/filesystem/explorer.rs
@@ -1,12 +1,11 @@
 use std::fs;
 use std::fs::read_dir;
 use std::ops::Deref;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use notify::event::CreateKind;
 use tauri::State;
 use crate::errors::Error;
 use crate::filesystem::cache::FsEventHandler;
-use crate::filesystem::fs_utils;
 use crate::filesystem::fs_utils::get_mount_point;
 use crate::filesystem::volume::DirectoryChild;
 use crate::StateSafe;

--- a/src-tauri/src/filesystem/mod.rs
+++ b/src-tauri/src/filesystem/mod.rs
@@ -1,10 +1,15 @@
+use serde::{Deserialize, Serialize};
+
 pub mod explorer;
 pub mod cache;
 pub mod volume;
 mod fs_utils;
 
-pub const DIRECTORY: &str = "directory";
-pub const FILE: &str = "file";
+#[derive(Serialize, Deserialize, PartialEq)]
+pub enum FileType{
+    Directory,
+    File
+}
 
 pub const fn bytes_to_gb(bytes: u64) -> u16 {
     (bytes / (1e+9 as u64)) as u16

--- a/src-tauri/src/filesystem/volume.rs
+++ b/src-tauri/src/filesystem/volume.rs
@@ -1,7 +1,7 @@
 use crate::filesystem::cache::{
     load_system_cache, run_cache_interval, save_system_cache, FsEventHandler, CACHE_FILE_PATH,
 };
-use crate::filesystem::{bytes_to_gb, DIRECTORY, FILE};
+use crate::filesystem::{bytes_to_gb, FileType};
 use crate::{CachedPath, StateSafe};
 use notify::{RecursiveMode, Watcher};
 use rayon::prelude::*;
@@ -73,11 +73,10 @@ impl Volume {
 
                 let walkdir_filetype = entry.file_type();
                 let file_type = if walkdir_filetype.is_dir() {
-                    DIRECTORY
+                    FileType::Directory
                 } else {
-                    FILE
-                }
-                .to_string();
+                    FileType::File
+                };
 
                 let cache_guard = &mut system_cache.lock().unwrap();
                 cache_guard

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod filesystem;
 mod search;
 mod errors;
 
+use filesystem::FileType;
 use filesystem::explorer::{open_file, open_directory, create_file, create_directory, rename_file, delete_file};
 use filesystem::volume::get_volumes;
 use search::search_directory;
@@ -17,7 +18,7 @@ pub struct CachedPath {
     #[serde(rename = "p")]
     file_path: String,
     #[serde(rename = "t")]
-    file_type: String,
+    file_type: FileType,
 }
 
 pub type VolumeCache = HashMap<String, Vec<CachedPath>>;

--- a/src-tauri/src/search.rs
+++ b/src-tauri/src/search.rs
@@ -1,4 +1,5 @@
 use crate::filesystem::volume::DirectoryChild;
+use crate::filesystem::FileType;
 use crate::StateSafe;
 use fuzzy_matcher::skim::SkimMatcherV2;
 use fuzzy_matcher::FuzzyMatcher;
@@ -92,7 +93,7 @@ pub async fn search_directory(
                 continue;
             }
 
-            if file_type == "file" {
+            if *file_type == FileType::File {
                 check_file(
                     &matcher,
                     accept_files,


### PR DESCRIPTION
This pull request replaces the constants `DIRECTORY` and `FILE` inside `src-tauri/src/filesystem/mod.rs` with an enum called `FileType` as suggested here #60. This is makes the code more idiomatic and improves efficiency as we are no longer storing an entire `str` in memory.