### PR TITLE
Changed README.md to add Linux build and run support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Before contributing please read the [contributing guidelines](./CONTRIBUTING.md)
 
 ## Supported operating systems
 - Windows
+- Linux (tested on Ubuntu 22.04 LTS)
 
 There are some issues with Linux and Mac but we shall work on these soon.
+More testing with different Linux distributions is required to ensure compatibillity across all of them.
 
 Bear in mind this is still in development and missing the following core features:
 - Caching service (constant file watching to keep cache up to date) - only works when program is open
@@ -32,7 +34,7 @@ Bear in mind this is still in development and missing the following core feature
 #  Make sure you have Tauri CLI installed
 cargo install tauri-cli
 
-# Install dependencies
+# Install Web dependencies
 yarn
 
 # Run app for development
@@ -41,3 +43,38 @@ cargo tauri dev
 # Build for production
 cargo tauri build
 ```
+## Steps for Debian-like distributions (Tauri v1.3)
+```
+#  Make sure you have Tauri CLI installed
+cargo install tauri-cli
+
+# Install Web dependencies
+yarn
+
+# Install Tauri dependencies (for runtime and building)
+sudo apt update
+sudo apt install libwebkit2gtk-4.0-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libssl-dev \
+    libgtk-3-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev
+
+# Run app for development
+cargo tauri dev
+
+# Build for production
+cargo tauri build
+
+```
+
+**NOTE: For all `cargo tauri` commands, run the commands in a terminal outside an IDE or text editor, because there is an issue where some IDEs and text editors set the $GTK_PATH to a custom folder. Causing `cargo tauri dev` and `cargo tauri build` to not work properly.**
+
+**Running the application binary from a terminal in an IDE or text editor also causes the application to not work properly**
+
+
+
+


### PR DESCRIPTION
Linux building was tested only on Ubuntu 22.04. But support for other distros should work, because the instructions for setting up Tauri for Linux also have instructions for other distros, so it should work. But, to ensure things don't go wrong, I have only put instructions for Ubuntu and other Debian-like distros.

Here is the webpage on the Tauri website for Linux systems:
https://tauri.app/v1/guides/getting-started/prerequisites#setting-up-linux